### PR TITLE
Drop tncc-emulate.py from package

### DIFF
--- a/rpm/openconnect.spec
+++ b/rpm/openconnect.spec
@@ -37,7 +37,6 @@ for NetworkManager etc.
 %package doc
 Summary:    Documentation for %{name}
 Requires:   %{name} = %{version}-%{release}
-Obsoletes:  %{name}-docs
 
 %description doc
 Man page for %{name}.

--- a/rpm/openconnect.spec
+++ b/rpm/openconnect.spec
@@ -26,7 +26,6 @@ HTTPS and DTLS protocols.
 
 %package devel
 Summary:    Development package for OpenConnect VPN authentication tools
-Group:      Applications/Internet
 Requires:   %{name} = %{version}-%{release}
 Provides:   openconnect-devel-static = %{version}-%{release}
 
@@ -37,7 +36,6 @@ for NetworkManager etc.
 
 %package doc
 Summary:    Documentation for %{name}
-Group:      Documentation
 Requires:   %{name} = %{version}-%{release}
 Obsoletes:  %{name}-docs
 

--- a/rpm/openconnect.spec
+++ b/rpm/openconnect.spec
@@ -56,7 +56,6 @@ rm -rf %{buildroot}
 %make_install
 rm -rf %{buildroot}%{_datadir}/openconnect
 rm -rf %{buildroot}%{_datadir}/bash-completion
-rm -f %{buildroot}%{_libexecdir}/openconnect/tncc-wrapper.py
 
 mkdir -p %{buildroot}%{_docdir}/%{name}-%{version}
 
@@ -69,6 +68,7 @@ mkdir -p %{buildroot}%{_docdir}/%{name}-%{version}
 %files -f %{name}.lang
 # Do not pull in Python3
 %exclude %{_libexecdir}/openconnect/tncc-emulate.py
+%exclude %{_libexecdir}/openconnect/tncc-wrapper.py
 %defattr(-,root,root,-)
 %license COPYING.LGPL
 %{_libdir}/libopenconnect.so.*

--- a/rpm/openconnect.spec
+++ b/rpm/openconnect.spec
@@ -69,6 +69,8 @@ mkdir -p %{buildroot}%{_docdir}/%{name}-%{version}
 %postun -p /sbin/ldconfig
 
 %files -f %{name}.lang
+# Do not pull in Python3
+%exclude %{_libexecdir}/openconnect/tncc-emulate.py
 %defattr(-,root,root,-)
 %license COPYING.LGPL
 %{_libdir}/libopenconnect.so.*


### PR DESCRIPTION
tncc-emulate.py was pulling Python3 to default images.

In addition, this PR cleans up groups, unnecessary Obsoletes as we had done a stop release, and tncc-wrapper.py also marked with exclude.